### PR TITLE
Make gh actions work again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="${GITHUB_REPOSITORY}" "${PULL_REQUEST}"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -32,4 +32,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "${BRANCH}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -31,7 +31,7 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot 
+      - run: brew test-bot
 
       - run: brew test-bot --only-formulae --root-url=https://ghcr.io/v2/zegervdv/zathura
         if: github.event_name == 'pull_request'

--- a/convert-into-app.sh
+++ b/convert-into-app.sh
@@ -5,15 +5,17 @@ echo "This script will convert the zathura binary into a macOS App"
 ZATHURA_EXE_DEFAULT="/opt/homebrew/bin/zathura"
 ZATHURA_EXE_FROM_PATH="$(command -v zathura)"
 
-if [[ -f "${ZATHURA_EXE_DEFAULT}" ]]; then
-    echo "zathura executable found at ${ZATHURA_EXE_DEFAULT}"
-    ZATHURA_EXE="${ZATHURA_EXE_DEFAULT}"
-elif [[ -f "${ZATHURA_EXE_FROM_PATH}" ]]; then
-    echo "zathura executable not found at ${ZATHURA_EXE_DEFAULT}; use ${ZATHURA_EXE_FROM_PATH} from \$PATH instead"
-    ZATHURA_EXE="${ZATHURA_EXE_FROM_PATH}"
+if [[ -f "${ZATHURA_EXE_DEFAULT}" ]]
+then
+  echo "zathura executable found at ${ZATHURA_EXE_DEFAULT}"
+  ZATHURA_EXE="${ZATHURA_EXE_DEFAULT}"
+elif [[ -f "${ZATHURA_EXE_FROM_PATH}" ]]
+then
+  echo "zathura executable not found at ${ZATHURA_EXE_DEFAULT}; use ${ZATHURA_EXE_FROM_PATH} from \$PATH instead"
+  ZATHURA_EXE="${ZATHURA_EXE_FROM_PATH}"
 else
-    echo "zathura executable not found neither at ${ZATHURA_EXE_DEFAULT}, nor in \$PATH"
-    exit 1
+  echo "zathura executable not found neither at ${ZATHURA_EXE_DEFAULT}, nor in \$PATH"
+  exit 1
 fi
 
 echo "Creating /Applications/Zathura.app"
@@ -22,7 +24,7 @@ mkdir -p /Applications/Zathura.app/Contents/Resources
 cp "${ZATHURA_EXE}" /Applications/Zathura.app/Contents/MacOS/zathura
 touch /Applications/Zathura.app/Contents/Info.plist
 
-read -r -d '' info_plist <<- EOF
+read -r -d '' info_plist <<-EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -45,7 +47,7 @@ read -r -d '' info_plist <<- EOF
 </plist>
 EOF
 
-echo "${info_plist}" > /Applications/Zathura.app/Contents/Info.plist
+echo "${info_plist}" >/Applications/Zathura.app/Contents/Info.plist
 
 echo "Getting the icon"
 curl -o /Applications/Zathura.app/Contents/Resources/AppIcon.icns https://raw.githubusercontent.com/homebrew-zathura/homebrew-zathura/132bb38829938ed8dfdd24f46946aab93f4482e5/icon/zathura-brosasaki.icns
@@ -53,7 +55,7 @@ curl -o /Applications/Zathura.app/Contents/Resources/AppIcon.icns https://raw.gi
 echo "Making it executable"
 chmod +x /Applications/Zathura.app/Contents/MacOS/zathura
 
-cat << EOF
+cat <<EOF
 Now you can run the app by double clicking on it.
 
 Next steps:


### PR DESCRIPTION
Current GH actions are failing. This PR aimed to fix them.

Current problems are following:
- `.github/workflows/tests.yml` uses outdated version of `actions/cache`;
- `.github/workflows/publish.yml` has several warnings with following idea: change `VAR` to `"${VAR}"`;
- `convert-into-app.sh` isn't well formatted: wring indentation (it uses 4 spaces instead of 2), several places has extra space (e.g. `>> FILE` instead of `>>FILE`), `then` should be on a separate line.
