### PR TITLE
Fix CI warnings

### DIFF
--- a/Formula/zathura.rb
+++ b/Formula/zathura.rb
@@ -21,8 +21,8 @@ class Zathura < Formula
   depends_on "gettext"
   depends_on "girara"
   depends_on "glib"
-  depends_on "json-glib"
   depends_on "intltool"
+  depends_on "json-glib"
   depends_on "libmagic"
   depends_on "synctex" => :optional
   on_macos do


### PR DESCRIPTION
Based on error message
```
Taps/homebrew-zathura/homebrew-zathura/Formula/zathura.rb:25:3: C: [Correctable] FormulaAudit/DependencyOrder: dependency "intltool" (line 25) should be put before dependency "json-glib" (line 27)
    depends_on "intltool"
    ^^^^^^^^^^^^^^^^^^^^^
```